### PR TITLE
TW-64305: Create Major version tag on merge

### DIFF
--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -42,8 +42,17 @@ jobs:
       # See https://github.com/im-open/git-version-lite for more details around how to increment
       # major/minor/patch through commit messages
       - name: Increment the version
-        uses: im-open/git-version-lite@v2.1.0
+        uses: im-open/git-version-lite@v2
+        id: version
         with:
           create-ref: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           default-release-type: major
+
+      - name: Create Major and Latest Tags
+        uses: im-open/create-tags-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{ steps.version.outputs.NEXT_VERSION_SHA }}
+          source-tag: ${{ steps.version.outputs.NEXT_VERSION }}
+          include-major: true

--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -37,7 +37,6 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          persist-credentials: false
 
       # See https://github.com/im-open/git-version-lite for more details around how to increment
       # major/minor/patch through commit messages
@@ -45,14 +44,16 @@ jobs:
         uses: im-open/git-version-lite@v2
         id: version
         with:
-          create-ref: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           default-release-type: major
 
-      - name: Create Major and Latest Tags
-        uses: im-open/create-tags-action@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          sha: ${{ steps.version.outputs.NEXT_VERSION_SHA }}
-          source-tag: ${{ steps.version.outputs.NEXT_VERSION }}
-          include-major: true
+      - name: Create version tag, create or update major, and minor tags
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git tag ${{ steps.version.outputs.NEXT_VERSION }} ${{ github.sha }}
+          git tag -f ${{ steps.version.outputs.NEXT_MAJOR_VERSION }} ${{ github.sha }}
+          git tag -f ${{ steps.version.outputs.NEXT_MINOR_VERSION }} ${{ github.sha }}
+          git push origin ${{ steps.version.outputs.NEXT_VERSION }}
+          git push origin ${{ steps.version.outputs.NEXT_MAJOR_VERSION }} -f
+          git push origin ${{ steps.version.outputs.NEXT_MINOR_VERSION }} -f

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: 'Transition Jira Ticket to Deployed Status'
         # You may also reference just the major or major.minor version
-        uses: im-open/transition-jira-tasks-by-query@v1.1.1
+        uses: im-open/transition-jira-tasks-by-query@v1.1.2
         with:
           jira-username: 'some-user'
           jira-password: ${{ secrets.JIRA_USER_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: 'Transition Jira Ticket to Deployed Status'
+        # You may also reference just the major or major.minor version
         uses: im-open/transition-jira-tasks-by-query@v1.1.1
         with:
           jira-username: 'some-user'

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: 'Transition Jira Tasks by Query'
+name: Transition Jira Tasks by Query
 
-description: 'Performs the given JQL query to find tickets and transition them to the given status.'
+description: Performs the given JQL query to find tickets and transition them to the given status.
 
 inputs:
   domain-name:


### PR DESCRIPTION
First review requested with the Infra Purple team originated in [ITHD-204625](https://jira.extendhealth.com/servicedesk/customer/portal/26/ITHD-204625). Since then the ownership of this repo has changed to the BC Swat team.  This work is now recorded in [TW-64305](https://jira.extendhealth.com/browse/TW-64305) and listed on their team's board.

# Summary of PR changes
Allow the creation of a major tag adjacent to the normal major + minor + patch release creation.

This allows downstream workflows to reference the major version instead of the specific minor + patch. Doing so will reduce dependabot alerts and unnecessary PRs to get the latest minor versions.

This is similar to the same pattern used with GitHub Actions.
https://github.com/actions/toolkit/blob/main/docs/action-versioning.md#recommendations

As an example, release `v1.2.3` is created with an accompanying `v1` tag.  Downstream consumers of this repo can reference `v1` instead of `v1.2.3`.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
