### PR TITLE
Rename all to issue

### DIFF
--- a/.github/workflows/auto-update-readme.yml
+++ b/.github/workflows/auto-update-readme.yml
@@ -51,7 +51,7 @@ jobs:
         if: steps.action-code.outputs.HAS_CHANGES == 'true'
         uses: im-open/update-action-version-in-file@v1.0.0
         with:
-          file-to-update: './src/transition-jira-tasks.ps1'
+          file-to-update: './src/transition-jira-issues.ps1'
           action-name: ${{ github.repository }}
           updated-version: ${{ steps.version.outputs.NEXT_VERSION }}
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# transition-jira-tasks-by-query
+# transition-jira-issues
 
-This GitHub Action will query Jira using JQL provided as an input, and will transition any tickets it finds to a given status.
+This GitHub Action will query Jira using JQL provided as an input, and will transition any issues it finds to a given status.
 
 ## Requirements
 
@@ -8,7 +8,7 @@ If the Jira server is hosted on an internal network, then the action must run on
 
 ## Index
 
-- [transition-jira-tasks-by-query](#transition-jira-tasks-by-query)
+- [transition-jira-issues](#transition-jira-issues)
   - [Index](#index)
   - [Inputs](#inputs)
   - [Example](#example)
@@ -19,16 +19,17 @@ If the Jira server is hosted on an internal network, then the action must run on
 
 
 ## Inputs
+Work items, tickets, etc. are referenced as "issues" in this action.
 
 | Parameter                          | Is Required    | Description                                                                                                                                                                                                                      |
 |------------------------------------|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `domain-name`                      | true           | The domain name for Jira.                                                                                                                                                                                                        |
-| `jql-query`                        | conditionally* | The JQL query to use to find tickets that will be transitioned. A max of 20 issues can be transitioned.                                                                                                                          |
+| `jql-query`                        | conditionally* | The JQL query to use to find issues that will be transitioned. A max of 20 issues can be transitioned.                                                                                                                          |
 | `issues`                           | conditionally* | Comma delimited list of issues to transition. Use `im-open/get-workitems-action` to identify list of issues for a PR or deployment.                                                                                              |
 | `transition-name`                  | true           | The name of the transition to perform. _Examples might include Open, In Progress, Deployed, etc._                                                                                                                                |
 | `update-fields`                    | false          | A [map](#updating-fields) of issue screen fields to overwrite, specifying the sub-field to update and its static value(s) for each field. When multiple sub-fields or other operations are required, use 'process-operations' input instead. |
 | `process-operations`               | false          | A [map](#updating-fields) containing the field name and a list of operations to perform. _The fields included in here cannot be included in 'update-fields' input._                                                                     |
-| `comment`                          | false          | Add a comment to the ticket after the transition.                                                                                                                                                                                |
+| `comment`                          | false          | Add a comment to the issue after the transition.                                                                                                                                                                                |
 | `missing-transition-as-successful` | false          | Mark as a successful if issue is missing the transition. _`true` by default._                                                                                                                                                    |
 | `fail-on-transition-failure`       | false          | Fail if some issues failed transitioning. _`true` by default._                                                                                                                                                                   |
 | `fail-if-issue-not-found`          | false          | Fail if some issues are not found that are listed in the `issues` input. _`true` by default._                                                                                                                                    |
@@ -56,7 +57,7 @@ If the Jira server is hosted on an internal network, then the action must run on
 
 ```yml
 jobs:
-  transition-jira-ticket:
+  transition-jira-issue:
     runs-on: ubuntu-20.04
     steps:
 
@@ -68,9 +69,9 @@ jobs:
           reference: v1.2.3
           github-token: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Transition Jira Ticket to Deployed Status
+      - name: Transition Jira Issue to Deployed Status
         # You may also reference just the major or major.minor version
-        uses: im-open/transition-jira-tasks-by-query@v2.0.0
+        uses: im-open/transition-jira-issues@v2.0.0
         id: transition
         with:
           jira-username: ${{ vars.JIRA_USERNAME }}
@@ -97,8 +98,8 @@ jobs:
       # Some issue types don't have a transition status like others.  
       # In those cases, where you want to still transition, a second step will need to be invoked.  
       # You can pass in the `unavailable-issues` output to transition those remaining issues.
-      - name: Transition Remaining Jira Tickets to Closed Status
-        uses: im-open/transition-jira-tasks-by-query@v2.0.0
+      - name: Transition Remaining Jira issues to Closed Status
+        uses: im-open/transition-jira-issues@v2.0.0
         with:
           jira-username: ${{ vars.JIRA_USERNAME }}
           jira-password: ${{ secrets.JIRA_PASSWORD }}
@@ -143,7 +144,7 @@ _The `update-fields` input would be something like:_
 
 ### Update Operations Input
 
-Update fields by operation(s). Adding multiple components, creating a link to another ticket, adding additional values to a multi-select field, etc.  Updating operations allows you to add or remove additional values to fields without overwriting what is already there.
+Update fields by operation(s). Adding multiple components, creating a link to another issue, adding additional values to a multi-select field, etc.  Updating operations allows you to add or remove additional values to fields without overwriting what is already there.
 
 _The `process-operations` fields would be something like:_
 

--- a/Test-Transition-Jira-Issue.ps1
+++ b/Test-Transition-Jira-Issue.ps1
@@ -79,7 +79,7 @@ try {
     exit 1
   }
     
-  $result = Invoke-JiraTransitionTicket `
+  $result = Invoke-JiraTransitionIssue `
     -Issue $issues[0] `
     -TransitionName $TransitionName `
     -Fields $Fields `
@@ -88,11 +88,11 @@ try {
     -AuthorizationHeaders $authorizationHeaders `
 
   If ($result -ne [TransitionResultType]::Success) {
-    Write-Error "Failed to transition ticket to the state [$TransitionName] with a result of [$result]"
+    Write-Error "Failed to transition issue to the state [$TransitionName] with a result of [$result]"
     exit 1
   }
     
-  Write-Information "Successfully transitioned ticket to state [$TransitionName] with a result of [$result]"
+  Write-Information "Successfully transitioned issue to state [$TransitionName] with a result of [$result]"
 }
 finally {
   Remove-Module JiraApis

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Transition Jira Tasks by Query
-description: Performs the given JQL query to find tickets and transition them to the given status.
+description: Performs the given JQL query to find issues and transition them to the given status.
 
 inputs:
   domain-name:
@@ -7,7 +7,7 @@ inputs:
     required: true
     
   jql-query:
-    description: The JQL query to use to find tickets that will be transitioned. If provided, will override any issues passed in the 'issues' input.
+    description: The JQL query to use to find issues that will be transitioned. If provided, will override any issues passed in the 'issues' input.
     required: false
     
   issues:
@@ -27,7 +27,7 @@ inputs:
     required: false
     
   comment:
-    description: Add a comment to the ticket after the transition
+    description: Add a comment to the issue after the transition
     required: false
 
   missing-transition-as-successful:
@@ -103,7 +103,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Transition Jira Tickets
+    - name: Transition Jira issues
       id: transition
       shell: pwsh
       env:
@@ -131,7 +131,7 @@ runs:
         $Fields = $env:FIELDS | ConvertFrom-Json -AsHashtable
         $Updates = $env:UPDATES | ConvertFrom-Json -AsHashtable
         
-        ${{ github.action_path }}/src/transition-jira-tasks.ps1 `
+        ${{ github.action_path }}/src/transition-jira-issues.ps1 `
           -JiraDomain "${{ inputs.domain-name }}" `
           -JqlToQueryBy $JqlToQueryBy `
           -IssueKeys $IssueKeys `
@@ -150,4 +150,4 @@ runs:
       if: ${{ inputs.create-notice == 'true' && steps.transition.outputs.isSuccessful == 'true' }}
       shell: pwsh
       run: |
-        Write-Output "::notice title=Jira Ticket Transitions::${{ steps.transition.outputs.processedIssues }} successfully processed and transitioned (if available) to [${{ inputs.transition-name }}]" 
+        Write-Output "::notice title=Jira Issue Transitions::${{ steps.transition.outputs.processedIssues }} successfully processed and transitioned (if available) to [${{ inputs.transition-name }}]" 

--- a/src/modules/JiraApis.psm1
+++ b/src/modules/JiraApis.psm1
@@ -178,7 +178,7 @@ Function Get-JiraIssue {
 # https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/#api-rest-api-2-issue-issueidorkey-put
 # Eventhough its API shows it can transition an issue, it doesn't work for some reason.
 # Thus we use the Transition endpoint instead for that use case.
-Function Edit-JiraTicket {
+Function Edit-JiraIssue {
   [OutputType([bool])]
   Param (
     [hashtable]$AuthorizationHeaders = @{},
@@ -234,7 +234,7 @@ Function Edit-JiraTicket {
 # Can only transition if all required fields are set (this is setup within Jira)
 # Can only update a field if it is on the transition screen. 
 # Thus its better to update fields in a seperate call to the edit issue endpoint
-Function Push-JiraTicketTransition {
+Function Push-JiraIssueTransition {
     [OutputType([bool])]
     Param (
         [hashtable]$AuthorizationHeaders = @{},
@@ -355,4 +355,4 @@ class JiraHttpRequesetException : System.Net.Http.HttpRequestException {
   }
 }
 
-Export-ModuleMember -Function Push-JiraTicketTransition, Get-JiraTransitionsByIssue, Get-JiraIssuesByQuery, Get-JiraIssue, Edit-JiraTicket, Get-AuthorizationHeaders
+Export-ModuleMember -Function Push-JiraIssueTransition, Get-JiraTransitionsByIssue, Get-JiraIssuesByQuery, Get-JiraIssue, Edit-JiraIssue, Get-AuthorizationHeaders

--- a/src/modules/TransitionIssue.psm1
+++ b/src/modules/TransitionIssue.psm1
@@ -137,7 +137,7 @@ Function Get-ReducedUpdates {
 }
 
 # https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/#api-rest-api-3-issue-issueidorkey-transitions-post
-Function Invoke-JiraTransitionTicket {
+Function Invoke-JiraTransitionIssue {
     [OutputType([TransitionResultType])]
     Param (
         [hashtable]$AuthorizationHeaders,
@@ -180,7 +180,7 @@ Function Invoke-JiraTransitionTicket {
             $fieldIdLookup[$field.Value.name] = $id
         }
 
-        $edited = Edit-JiraTicket `
+        $edited = Edit-JiraIssue `
           -AuthorizationHeaders $AuthorizationHeaders `
           -Issue $Issue `
           -Fields (Get-ReducedFields -Fields $Fields -Issue $Issue -FieldIdLookup $fieldIdLookup) `
@@ -218,7 +218,7 @@ Function Invoke-JiraTransitionTicket {
         
         Write-Debug "[$issueKey] Transitioning $issueType from [$issueStatus] to [$TransitionName]..."
     
-        $processed = Push-JiraTicketTransition `
+        $processed = Push-JiraIssueTransition `
           -AuthorizationHeaders $AuthorizationHeaders `
           -Issue $Issue `
           -TransitionId $transitionId `
@@ -239,4 +239,4 @@ Function Invoke-JiraTransitionTicket {
     return $resultType
 }
 
-Export-ModuleMember -Function Invoke-JiraTransitionTicket
+Export-ModuleMember -Function Invoke-JiraTransitionIssue

--- a/src/transition-jira-issues.ps1
+++ b/src/transition-jira-issues.ps1
@@ -19,7 +19,7 @@ param (
 )
 
 $MAX_ISSUES_TO_TRANSITION = 20
-$MESSAGE_TITLE = "Jira Ticket Transitions"
+$MESSAGE_TITLE = "Jira Issue Transitions"
 
 $global:InformationPreference = "Continue"
 $isDebug = $env:RUNNER_DEBUG -eq "1" -Or $Debug
@@ -28,7 +28,7 @@ $global:DebugPreference = $isDebug ? "Continue" : "SilentlyContinue"
 $throttleLimit = $isDebug ? 1 : $MAX_ISSUES_TO_TRANSITION 
 
 $env:GITHUB_RUNNER_URL = "{0}/{1}/actions/runs/{2}" -f $env:GITHUB_SERVER_URL, $env:GITHUB_REPOSITORY, $env:GITHUB_RUN_ID 
-$env:GITHUB_ACTION_URL = "{0}/{1}" -f $env:GITHUB_SERVER_URL, "im-open/transition-jira-tasks-by-query@v2.0.0"
+$env:GITHUB_ACTION_URL = "{0}/{1}" -f $env:GITHUB_SERVER_URL, "im-open/transition-jira-issues@v2.0.0"
 
 Function Write-IssueListOutput {
   Param (
@@ -119,7 +119,7 @@ try {
         $safeFailIfJiraInaccessible = $using:FailIfJiraInaccessible
        
         try {
-            $resultType = Invoke-JiraTransitionTicket `
+            $resultType = Invoke-JiraTransitionIssue `
               -AuthorizationHeaders $using:AuthorizationHeaders `
               -Issue $issue `
               -TransitionName $safeTranstionName `


### PR DESCRIPTION
# Summary of PR changes

The project uses issues, tickets and tasks  terms to reference a Jira Issue. Consolidate all to one term `issue`.

This also requires the repo to be renamed to `transition-jira-issues`.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
