### PR TITLE
Compare against transition IDs instead of names

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ jobs:
       
       - name: Transition Jira Issue to Deployed Status
         # You may also reference just the major or major.minor version
-        uses: im-open/transition-jira-issues@v2.1.0
+        uses: im-open/transition-jira-issues@v2.1.1
         id: transition
         with:
           jira-username: ${{ vars.JIRA_USERNAME }}
@@ -101,7 +101,7 @@ jobs:
       # In those cases, where you want to still transition, a second step will need to be invoked.  
       # You can pass in the `unavailable-issues` output to transition those remaining issues.
       - name: Transition Remaining Jira issues to Closed Status
-        uses: im-open/transition-jira-issues@v2.1.0
+        uses: im-open/transition-jira-issues@v2.1.1
         with:
           jira-username: ${{ vars.JIRA_USERNAME }}
           jira-password: ${{ secrets.JIRA_PASSWORD }}

--- a/src/modules/TransitionIssue.psm1
+++ b/src/modules/TransitionIssue.psm1
@@ -191,15 +191,6 @@ Function Invoke-JiraTransitionIssue {
         }
 
         $transitionId = ($Issue.transitions | Where-Object { $_.name, $_.toName -icontains $TransitionName }).id
-        $currentTransitionId = ($Issue.transitions | Where-Object { $_.name, $_.toName -icontains $issueStatus }).id
-      
-        If ($currentTransitionId -ieq $transitionId -Or $issueStatus -ieq $TransitionName) {
-            "[$issueKey] $issueType already in status [$issueStatus]. Skipping transition! Available transitions: $($Issue.availableTransitionNames -join ', ')" `
-              | Write-Information
-    
-            return [TransitionResultType]::Skipped 
-        }
-
         If ($null -eq $transitionId) {
             "[$issueKey] Missing transition [$TransitionName] on $issueType! Currently in [$issueStatus] state. Available transitions: $($availableTransitionNames -join ', ')" `
               | Write-Information 
@@ -211,6 +202,14 @@ Function Invoke-JiraTransitionIssue {
               | Write-Warning
     
             return [TransitionResultType]::Unavailable
+        }
+
+        $currentTransitionId = ($Issue.transitions | Where-Object { $_.name, $_.toName -icontains $issueStatus }).id
+        If ($currentTransitionId -eq $transitionId) {
+          "[$issueKey] $issueType already in status [$issueStatus]. Skipping transition! Available transitions: $($Issue.availableTransitionNames -join ', ')" `
+              | Write-Information
+
+          return [TransitionResultType]::Skipped
         }
         
         Write-Debug "[$issueKey] Transitioning $issueType from [$issueStatus] to [$TransitionName]..."

--- a/src/modules/TransitionIssue.psm1
+++ b/src/modules/TransitionIssue.psm1
@@ -189,15 +189,17 @@ Function Invoke-JiraTransitionIssue {
               return [TransitionResultType]::Failed
           }
         }
+
+        $transitionId = ($Issue.transitions | Where-Object { $_.name, $_.toName -icontains $TransitionName }).id
+        $currentTransitionId = ($Issue.transitions | Where-Object { $_.name, $_.toName -icontains $issueStatus }).id
       
-        If ($issueStatus -ieq $TransitionName) {
+        If ($currentTransitionId -ieq $transitionId -Or $issueStatus -ieq $TransitionName) {
             "[$issueKey] $issueType already in status [$issueStatus]. Skipping transition! Available transitions: $($Issue.availableTransitionNames -join ', ')" `
               | Write-Information
     
             return [TransitionResultType]::Skipped 
         }
 
-        $transitionId = ($Issue.transitions | Where-Object { $_.name, $_.toName -icontains $TransitionName }).id
         If ($null -eq $transitionId) {
             "[$issueKey] Missing transition [$TransitionName] on $issueType! Currently in [$issueStatus] state. Available transitions: $($availableTransitionNames -join ', ')" `
               | Write-Information 

--- a/src/modules/TransitionIssue.psm1
+++ b/src/modules/TransitionIssue.psm1
@@ -190,26 +190,26 @@ Function Invoke-JiraTransitionIssue {
           }
         }
 
+        If ($issueStatus -ieq $TransitionName) {
+            "[$issueKey] $issueType already in status [$issueStatus]. Skipping transition! Available transitions: $($availableTransitionNames -join ', ')" `
+              | Write-Information
+
+            return [TransitionResultType]::Skipped
+        }
+
         $transitionId = ($Issue.transitions | Where-Object { $_.name, $_.toName -icontains $TransitionName }).id
         If ($null -eq $transitionId) {
             "[$issueKey] Missing transition [$TransitionName] on $issueType! Currently in [$issueStatus] state. Available transitions: $($availableTransitionNames -join ', ')" `
-              | Write-Information 
-    
+              | Write-Information
+
             return [TransitionResultType]::Unavailable
         }
+        
         If ($transitionId.Count -gt 1) {
             "[$issueKey] Multiple transitions found for [$TransitionName] on $issueType! Available transitions: $($transitionId -join ', ')" `
               | Write-Warning
     
             return [TransitionResultType]::Unavailable
-        }
-
-        $currentTransitionId = ($Issue.transitions | Where-Object { $_.name, $_.toName -icontains $issueStatus }).id
-        If ($currentTransitionId -eq $transitionId) {
-          "[$issueKey] $issueType already in status [$issueStatus]. Skipping transition! Available transitions: $($Issue.availableTransitionNames -join ', ')" `
-              | Write-Information
-
-          return [TransitionResultType]::Skipped
         }
         
         Write-Debug "[$issueKey] Transitioning $issueType from [$issueStatus] to [$TransitionName]..."

--- a/src/transition-jira-issues.ps1
+++ b/src/transition-jira-issues.ps1
@@ -95,15 +95,14 @@ try {
         Write-Debug $_.ScriptStackTrace
     }
     
-    If ($issues.Length -eq 0 -And !$FailIfJiraInaccessible -And $CreateWarningNotices) {
-        "::warning title=$MESSAGE_TITLE::No issues were found that match query {$JqlToQueryBy}. Jira might be down. Skipping check..." `
-          | Write-Output
-    }
-
     If ($issues.Length -gt $MAX_ISSUES_TO_TRANSITION) {
         "Too many issues returned by the query [$($issues.Length)]. Adjust the the query to return less than or equal to $MAX_ISSUES_TO_TRANSITION issues." `
           | Write-Error
         Exit 1
+    }
+
+    If ($issues.Length -eq 0 -And !$FailIfJiraInaccessible -And $CreateWarningNotices) {
+        Write-Warning "No issues were found that match query {$JqlToQueryBy}. Jira might be down. Skipping check..."
     }
 
     If ($issues.Length -gt 0) {
@@ -180,30 +179,20 @@ try {
     
     # Notices on Runner
     # ------------
-    If ($identifiedIssueKeys.Length -eq 0 -And $FailOnTransitionFailure) {
-        Write-Output "::error title=$MESSAGE_TITLE::No issues were successfully transitioned. See job logs for details and action $env:GITHUB_ACTION_URL for additional help."
-        Exit 1
-    }
-
-    If ($identifiedIssueKeys.Length -eq 0 -And !$FailOnTransitionFailure) {
-        If ($CreateWarningNotices) { Write-Output "::warning title=$MESSAGE_TITLE::No issues were successfully transitioned. See job logs for details and action $env:GITHUB_ACTION_URL for additional help." }
-        Exit 0 
-    }
-
-    If ($unavailableTransitionIssueKeys.Length -gt 0 -And $FailOnTransitionFailure -And !$MissingTransitionAsSuccessful) {
-        Write-Output "::error title=$MESSAGE_TITLE::$($unavailableTransitionIssueKeys -join ', ') missing transition [$TransitionName]. You may enable 'missing-transition-as-successful' to treat these as a successful transition."
-        Exit 1
-    }
 
     If ($failedIssueKeys.Length -gt 0 -And $FailOnTransitionFailure) {
         Write-Output "::error title=$MESSAGE_TITLE::Failed to transition $( `
-          $failedIssueKeys -join ', ') to [$TransitionName]. You might need to include a missing field value or use the 'missing-transition-as-successful' action input. See job logs for details and action $env:GITHUB_ACTION_URL for additional help."
+          $failedIssueKeys -join ', ') to [$TransitionName]. You might need to include a missing field value or use the 'missing-transition-as-successful' action input to ignore missing transitions. See job logs for details and action $env:GITHUB_ACTION_URL for additional help."
         Exit 1
     }
 
     If ($failedIssueKeys.Length -gt 0 -And !$FailOnTransitionFailure -And $CreateWarningNotices) {
-        Write-Output "::warning title=$MESSAGE_TITLE::Unable to transition $( `
-          $failedIssueKeys -join ', ') to [$TransitionName]. You might need to include a missing field value. See job logs for details and action $env:GITHUB_ACTION_URL for additional help."
+        Write-Output "::warning title=$MESSAGE_TITLE::Unable to transition $($failedIssueKeys -join ', ') to [$TransitionName]."
+    }
+    
+    If ($unavailableTransitionIssueKeys.Length -gt 0 -And $FailOnTransitionFailure -And !$MissingTransitionAsSuccessful) {
+        Write-Output "::error title=$MESSAGE_TITLE::$($unavailableTransitionIssueKeys -join ', ') missing transition [$TransitionName]. You may enable 'missing-transition-as-successful' to treat these as a successful transition."
+        Exit 1
     }
 
     If ($excludedIssueKeys.Length -gt 0 -And $FailIfIssueExcluded) {
@@ -213,6 +202,10 @@ try {
 
     If ($excludedIssueKeys.Length -gt 0 -And !$FailIfIssueExcluded -And $CreateWarningNotices) {
         Write-Output "::warning title=$MESSAGE_TITLE::$($excludedIssueKeys -join ', ') excluded from origin query {$JqlToQueryBy}"
+    }
+
+    If ($excludedIssueKeys.Length -eq 0 -And $successfulyProcessedIssueKeys.Length -eq 0 -And $CreateWarningNotices) {
+        Write-Output "::warning title=$MESSAGE_TITLE::No issues were transitioned into [$TransitionName]."
     }
 
     Exit 0

--- a/src/transition-jira-issues.ps1
+++ b/src/transition-jira-issues.ps1
@@ -196,12 +196,12 @@ try {
     }
 
     If ($excludedIssueKeys.Length -gt 0 -And $FailIfIssueExcluded) {
-        Write-Output "::error title=$MESSAGE_TITLE::$($excludedIssueKeys -join ', ') excluded from origin query {$JqlToQueryBy}"
+        Write-Output "::error title=$MESSAGE_TITLE::$($excludedIssueKeys -join ', ') excluded from origin query"
         Exit 1
     }
 
     If ($excludedIssueKeys.Length -gt 0 -And !$FailIfIssueExcluded -And $CreateWarningNotices) {
-        Write-Output "::warning title=$MESSAGE_TITLE::$($excludedIssueKeys -join ', ') excluded from origin query {$JqlToQueryBy}"
+        Write-Output "::warning title=$MESSAGE_TITLE::$($excludedIssueKeys -join ', ') excluded from origin query"
     }
 
     If ($excludedIssueKeys.Length -eq 0 -And $successfulyProcessedIssueKeys.Length -eq 0 -And $CreateWarningNotices) {


### PR DESCRIPTION
# Summary of PR changes

Small bug where a transition name could have an alias.  If an issue is in that alias status, it will not skip but attempt to transition to the same status - producing an error.

Also rearrange warnings and errors so they occur in the correct order.  We were failing the action if the query returned 0 results when `fail-on-exclude` was marked as `false`.  It should not fail the action in that scenario.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
